### PR TITLE
Feat/stl deserialization validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,17 @@ ctest .
 
 # Requirements
 C++11 or higher.
+
+
+# DISCLAIMER: STL File Format #
+
+
+The STL file format, while widely used for 3D modeling and printing, was designed to be simple and easy to parse. However, this simplicity comes with some significant limitations:
+
+- Lack of Built-in Validation Mechanisms: The STL format does not include built-in mechanisms such as checksums, hashes, or any form of file validation. This makes it challenging to detect certain types of file corruption, such as a truncated header or malformed data. As a result, errors in file transmission, storage, or manipulation might go undetected.
+
+- Vulnerability to Corruption: Due to the lack of validation features, STL files can be easily corrupted. For example, if the file is truncated or contains invalid data, these issues may not be detected until the file is parsed or processed, potentially leading to crashes or undefined behavior in applications that use the file.
+
+- Potential for Buffer Overflow Attacks: The lack of built-in validation and the absence of bounds checking in the STL format can make it susceptible to buffer overflow attacks. Care should be taken when handling STL files, especially those from untrusted sources, to ensure they are properly validated before being used.
+
+These limitations are inherent to the STL format and should be considered when working with or implementing software that processes STL files. Developers are encouraged to implement additional validation and error-handling mechanisms in their applications to mitigate these risks.

--- a/tests/core/src/serialize.test.cpp
+++ b/tests/core/src/serialize.test.cpp
@@ -1,28 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
+#include "openstl/tests/testutils.h"
 #include "openstl/core/stl.h"
 
 using namespace openstl;
 
-
-// Custom equality operator for Vertex struct
-bool operator!=(const Vec3& rhs, const Vec3& lhs) {
-    return std::tie(rhs.x, rhs.y, rhs.z) != std::tie(lhs.x, lhs.y, lhs.z);
-}
-
-// Utility function to compare two vectors of triangles
-bool compareTriangles(const std::vector<Triangle>& a, const std::vector<Triangle>& b, bool omit_attribute=false) {
-    if (a.size() != b.size()) return false;
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (a[i].normal != b[i].normal ||
-            a[i].v0 != b[i].v0 ||
-            a[i].v1 != b[i].v1 ||
-            a[i].v2 != b[i].v2 ||
-            ((a[i].attribute_byte_count != b[i].attribute_byte_count) & !omit_attribute)) {
-            return false;
-        }
-    }
-    return true;
-}
 
 TEST_CASE("Serialize STL triangles", "[openstl]") {
     // Generate some sample triangles
@@ -51,7 +32,7 @@ TEST_CASE("Serialize STL triangles", "[openstl]") {
         auto deserializedTriangles = deserializeBinaryStl(inFile);
 
         // Validate deserialized triangles against original triangles
-        REQUIRE(compareTriangles(deserializedTriangles, originalTriangles));
+        REQUIRE(testutils::checkTrianglesEqual(deserializedTriangles, originalTriangles));
     }
 
     SECTION("Binary Format stringstream") {
@@ -65,7 +46,7 @@ TEST_CASE("Serialize STL triangles", "[openstl]") {
         auto deserializedTriangles = deserializeBinaryStl(ss);
 
         // Validate deserialized triangles against original triangles
-        REQUIRE(compareTriangles(deserializedTriangles, originalTriangles));
+        REQUIRE(testutils::checkTrianglesEqual(deserializedTriangles, originalTriangles));
     }
 
     SECTION("ASCII Format") {
@@ -88,6 +69,6 @@ TEST_CASE("Serialize STL triangles", "[openstl]") {
         auto deserializedTriangles = deserializeAsciiStl(inFile);
 
         // Validate deserialized triangles against original triangles
-        REQUIRE(compareTriangles(deserializedTriangles, originalTriangles, true));
+        REQUIRE(testutils::checkTrianglesEqual(deserializedTriangles, originalTriangles, true));
     }
 }

--- a/tests/utils/include/openstl/tests/testutils.h
+++ b/tests/utils/include/openstl/tests/testutils.h
@@ -1,12 +1,13 @@
 #ifndef OPENSTL_TESTS_TESTUTILS_H
 #define OPENSTL_TESTS_TESTUTILS_H
 #include "assets/assets_path.h"
+#include "openstl/core/stl.h"
 #include <string>
 
 namespace openstl {
     namespace testutils {
         enum class TESTOBJECT {
-            KEY, BALL, WASHER
+            KEY, BALL, WASHER, COMPROMISED_TRIANGLE_COUNT, EMPTY_FILE
         };
 
         inline std::string getTestObjectPath(TESTOBJECT obj) {
@@ -24,6 +25,157 @@ namespace openstl {
             }
             return OPENSTL_TEST_ASSETSDIR + basename;
         }
+
+        inline std::vector<Triangle> createTestTriangle() {
+            Triangle triangle;
+            triangle.normal = {0.1f, 0.2f, 1.0f};
+            triangle.v0 = {0.0f, 0.0f, 0.0f};
+            triangle.v1 = {1.0f, 0.0f, 0.0f};
+            triangle.v2 = {0.0f, 1.0f, 0.0f};
+            triangle.attribute_byte_count = 0;
+            return {triangle};
+        }
+
+        inline void createIncompleteTriangleData(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Write header (80 bytes for comments)
+            char header[80] = "STL Exported by OpenSTL [https://github.com/Innoptech/OpenSTL]";
+            file.write(header, sizeof(header));
+
+            // Write triangle count (4 bytes)
+            auto triangleCount = static_cast<uint32_t>(triangles.size());
+            file.write(reinterpret_cast<const char*>(&triangleCount), sizeof(triangleCount));
+
+            // Write only half of the triangles to simulate incomplete data
+            for (size_t i = 0; i < triangles.size() / 2; ++i) {
+                file.write(reinterpret_cast<const char*>(&triangles[i]), sizeof(Triangle));
+            }
+            file.close();
+        }
+
+        inline void createCorruptedHeaderTruncated(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Truncated header (less than 80 bytes)
+            char header[40] = "TruncatedHeader";
+            file.write(header, sizeof(header)); // Writing only 40 bytes instead of 80
+
+            // Write triangle count and triangles normally
+            auto triangleCount = static_cast<uint32_t>(triangles.size());
+            file.write(reinterpret_cast<const char*>(&triangleCount), sizeof(triangleCount));
+            for (const auto& tri : triangles) {
+                file.write(reinterpret_cast<const char*>(&tri), sizeof(Triangle));
+            }
+
+            file.close();
+        }
+
+        inline void createCorruptedHeaderExcessData(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Correct header followed by garbage data
+            char header[80] = "STL Exported by OpenSTL [https://github.com/Innoptech/OpenSTL]";
+            file.write(header, sizeof(header));
+
+            // Write some garbage data to corrupt the file
+            char garbage[20] = "GARBAGE DATA";
+            file.write(garbage, sizeof(garbage));
+
+            // Write triangle count and triangles normally
+            auto triangleCount = static_cast<uint32_t>(triangles.size());
+            file.write(reinterpret_cast<const char*>(&triangleCount), sizeof(triangleCount));
+            for (const auto& tri : triangles) {
+                file.write(reinterpret_cast<const char*>(&tri), sizeof(Triangle));
+            }
+
+            file.close();
+        }
+
+        inline void createExcessiveTriangleCount(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Write header (80 bytes for comments)
+            char header[80] = "STL Exported by OpenSTL [https://github.com/Innoptech/OpenSTL]";
+            file.write(header, sizeof(header));
+
+            // Write an excessive triangle count (much larger than actual size)
+            uint32_t excessiveCount = std::numeric_limits<uint32_t>::max(); // Adding 1000 to the actual count
+            file.write(reinterpret_cast<const char*>(&excessiveCount), sizeof(excessiveCount));
+            file.close();
+        }
+
+        inline void createCorruptedHeaderInvalidChars(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Corrupted header with random invalid characters
+            char header[80] = "CorruptedHeader12345!@#$%&*()";
+            file.write(header, sizeof(header));
+
+            // Write triangle count and triangles normally
+            auto triangleCount = static_cast<uint32_t>(triangles.size());
+            file.write(reinterpret_cast<const char*>(&triangleCount), sizeof(triangleCount));
+            for (const auto& tri : triangles) {
+                file.write(reinterpret_cast<const char*>(&tri), sizeof(Triangle));
+            }
+
+            file.close();
+        }
+
+        inline void createBufferOverflowOnTriangleCount(const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Write only the header (80 bytes) and close the file
+            char header[80] = "STL Exported by OpenSTL [https://github.com/Innoptech/OpenSTL]";
+            file.write(header, sizeof(header));
+            file.close();
+        }
+
+        inline void createStlWithTriangles(const std::vector<Triangle>& triangles, const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+
+            // Write a valid header
+            char header[80] = "STL Exported by Test";
+            file.write(header, sizeof(header));
+
+            // Write the number of triangles
+            uint32_t triangleCount = static_cast<uint32_t>(triangles.size());
+            file.write(reinterpret_cast<const char*>(&triangleCount), sizeof(triangleCount));
+
+            // Write the triangles
+            file.write(reinterpret_cast<const char*>(triangles.data()), triangles.size() * sizeof(Triangle));
+
+            file.close();
+        }
+
+
+        inline void createEmptyStlFile(const std::string& filename) {
+            std::ofstream file(filename, std::ios::binary);
+            // Simply create the file and close it without writing anything to it
+            file.close();
+        }
+
+        // Custom equality operator for Vertex struct
+        inline bool operator!=(const Vec3& rhs, const Vec3& lhs) {
+            return std::tie(rhs.x, rhs.y, rhs.z) != std::tie(lhs.x, lhs.y, lhs.z);
+        }
+
+        // Utility function to compare two vectors of triangles
+        inline bool checkTrianglesEqual(const std::vector<Triangle>& a, const std::vector<Triangle>& b, bool omit_attribute=false) {
+            if (a.size() != b.size()) return false;
+            for (size_t i = 0; i < a.size(); ++i) {
+                if (a[i].normal != b[i].normal ||
+                    a[i].v0 != b[i].v0 ||
+                    a[i].v1 != b[i].v1 ||
+                    a[i].v2 != b[i].v2 ||
+                    ((a[i].attribute_byte_count != b[i].attribute_byte_count) & !omit_attribute)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+
     } //namespace testutils
 } //namespace openstl
 #endif //OPENSTL_TESTS_TESTUTILS_H


### PR DESCRIPTION
This pull request enhances the STL deserialization process by adding validation for truncated headers and includes new unit tests to ensure robustness.
Key Changes:

## Deserializer Validation:
        Updated deserializeBinaryStl to check file size before reading the header, ensuring the file is large enough for a valid STL header and triangle count.
        Improved error handling to detect and throw exceptions for truncated or corrupt files.

## Unit Tests:
        Added tests for truncated headers, ensuring the deserializer throws an exception when encountering an incomplete header.
        Included tests for handling the maximum number of triangles and validating behavior when the limit is exceeded.

## Disclaimer:
        Added a disclaimer to the documentation, noting the limitations of the STL binary format and the absence of built-in validation mechanisms like checksums.